### PR TITLE
Update base image for Squid

### DIFF
--- a/deployment/helm/squid-proxy/values.yaml
+++ b/deployment/helm/squid-proxy/values.yaml
@@ -1,4 +1,4 @@
 # Squid proxy settings
 squidProxy:
-  image: datadog/squid
+  image: ubuntu/squid
   port: 3128


### PR DESCRIPTION
datadog/squid is no longer available, updating to use `ubunt/squid`