### PR TITLE
Updated helm charts to trigger new release of package for squid image.

### DIFF
--- a/deployment/helm/iot-edge-accelerator/Chart.yaml
+++ b/deployment/helm/iot-edge-accelerator/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.24.0
+version: 0.25.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/deployment/helm/squid-proxy/Chart.yaml
+++ b/deployment/helm/squid-proxy/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.18.0
+version: 0.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
Ideally, we should decouple squid and iot accelerator charts so they can be updated independently.