### PR TITLE
Set executable permission manifest tool for linux

### DIFF
--- a/lib/Industrial-IoT/tools/scripts/acr-build.ps1
+++ b/lib/Industrial-IoT/tools/scripts/acr-build.ps1
@@ -334,6 +334,10 @@ while ($true) {
         $wc.DownloadFile($url, $manifestToolPath)
 
         if (Test-Path $manifestToolPath) {
+            if ($IsLinux) {
+                Write-Host "Setting tool to be executable.."
+                chmod +x $manifestToolPath
+            }
             break
         }
     }


### PR DESCRIPTION
When running on linux, during the step of building and pushing the manifest file, the [manifest-tool](https://github.com/estesp/manifest-tool/) installed needs permission to be executable. 