### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -32,7 +32,7 @@ jobs:
     
     - name: Get the version
       id: vars
-      run: echo ::set-output name=tag::$(echo main-pr-$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH"))
+      run: echo tag=$(echo main-pr-$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")) >> "$GITHUB_OUTPUT"
     - name: echo tag
       run: echo ${{steps.vars.outputs.tag}}
       

--- a/.github/workflows/Release-squid-proxy.yml
+++ b/.github/workflows/Release-squid-proxy.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Get the version
       id: vars
-      run: echo ::set-output name=tag::$(echo main-${GITHUB_SHA})
+      run: echo tag=$(echo main-${GITHUB_SHA}) >> "$GITHUB_OUTPUT"
       
     - name: Echo Docker images tag
       run: echo ${{steps.vars.outputs.tag}}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter